### PR TITLE
Fix RAL import in sync-api-common/browser.d.ts

### DIFF
--- a/sync-api-common/browser.d.ts
+++ b/sync-api-common/browser.d.ts
@@ -3,6 +3,6 @@
  * Licensed under the MIT License. See License.txt in the project root for license information.
  * ----------------------------------------------------------------------------------------- */
 
-import RAL from './lib/browser/main';
+import { RAL } from './lib/browser/main';
 export * from './lib/browser/main';
 export default RAL;


### PR DESCRIPTION
RAL is no longer default-exported from lib/browser/main, so import it normally instead.