### PR TITLE
correctly match mountPoint mapping

### DIFF
--- a/wasm-wasi-core/src/common/rootFileSystemDriver.ts
+++ b/wasm-wasi-core/src/common/rootFileSystemDriver.ts
@@ -11,15 +11,15 @@ import { Errno } from './wasi';
 import RAL from './ral';
 
 const DirectoryBaseRights: rights = Rights.fd_fdstat_set_flags | Rights.path_create_directory |
-	Rights.path_create_file | Rights.path_link_source | Rights.path_link_target | Rights.path_open |
-	Rights.fd_readdir | Rights.path_readlink | Rights.path_rename_source | Rights.path_rename_target |
-	Rights.path_filestat_get | Rights.path_filestat_set_size | Rights.path_filestat_set_times |
-	Rights.fd_filestat_get | Rights.fd_filestat_set_times | Rights.path_remove_directory | Rights.path_unlink_file |
-	Rights.path_symlink;
+		Rights.path_create_file | Rights.path_link_source | Rights.path_link_target | Rights.path_open |
+		Rights.fd_readdir | Rights.path_readlink | Rights.path_rename_source | Rights.path_rename_target |
+		Rights.path_filestat_get | Rights.path_filestat_set_size | Rights.path_filestat_set_times |
+		Rights.fd_filestat_get | Rights.fd_filestat_set_times | Rights.path_remove_directory | Rights.path_unlink_file |
+		Rights.path_symlink;
 
 const FileBaseRights: rights = Rights.fd_datasync | Rights.fd_read | Rights.fd_seek | Rights.fd_fdstat_set_flags |
-	Rights.fd_sync | Rights.fd_tell | Rights.fd_write | Rights.fd_advise | Rights.fd_allocate | Rights.fd_filestat_get |
-	Rights.fd_filestat_set_size | Rights.fd_filestat_set_times | Rights.poll_fd_readwrite;
+		Rights.fd_sync | Rights.fd_tell | Rights.fd_write | Rights.fd_advise | Rights.fd_allocate | Rights.fd_filestat_get |
+		Rights.fd_filestat_set_size | Rights.fd_filestat_set_times | Rights.poll_fd_readwrite;
 
 const DirectoryInheritingRights: rights = DirectoryBaseRights | FileBaseRights;
 
@@ -296,7 +296,7 @@ export function create(deviceId: DeviceId, rootFileDescriptors: { getRoot(device
 	const $driver = {
 		kind: DeviceDriverKind.fileSystem as const,
 		id: deviceId,
-		uri: Uri.from({ scheme: 'wasi-root', path: '/' }),
+		uri: Uri.from( { scheme: 'wasi-root', path: '/' } ),
 		makeVirtualPath(deviceDriver: FileSystemDeviceDriver, filepath: string): string | undefined {
 			return $fs.makeVirtualPath(deviceDriver, filepath);
 		},

--- a/wasm-wasi-core/src/common/rootFileSystemDriver.ts
+++ b/wasm-wasi-core/src/common/rootFileSystemDriver.ts
@@ -244,7 +244,7 @@ class VirtualRootFileSystem {
 		for (const [mountPoint, node] of this.mountPoints) {
 			const root = node.deviceDriver.uri;
 			const rootStr = root.toString();
-			if (uriStr === rootStr || (uriStr.startsWith(rootStr) && uriStr.charAt(rootStr.length - 1) === '/')) {
+			if (uriStr === rootStr || uriStr.startsWith(rootStr)) {
 				return [mountPoint, root];
 			}
 		}

--- a/wasm-wasi-core/src/common/rootFileSystemDriver.ts
+++ b/wasm-wasi-core/src/common/rootFileSystemDriver.ts
@@ -296,7 +296,7 @@ export function create(deviceId: DeviceId, rootFileDescriptors: { getRoot(device
 	const $driver = {
 		kind: DeviceDriverKind.fileSystem as const,
 		id: deviceId,
-		uri: Uri.from( { scheme: 'wasi-root', path: '/' } ),
+		uri: Uri.from( { scheme: 'wasi-root', path: '/'} ),
 		makeVirtualPath(deviceDriver: FileSystemDeviceDriver, filepath: string): string | undefined {
 			return $fs.makeVirtualPath(deviceDriver, filepath);
 		},

--- a/wasm-wasi-core/src/common/rootFileSystemDriver.ts
+++ b/wasm-wasi-core/src/common/rootFileSystemDriver.ts
@@ -11,15 +11,15 @@ import { Errno } from './wasi';
 import RAL from './ral';
 
 const DirectoryBaseRights: rights = Rights.fd_fdstat_set_flags | Rights.path_create_directory |
-		Rights.path_create_file | Rights.path_link_source | Rights.path_link_target | Rights.path_open |
-		Rights.fd_readdir | Rights.path_readlink | Rights.path_rename_source | Rights.path_rename_target |
-		Rights.path_filestat_get | Rights.path_filestat_set_size | Rights.path_filestat_set_times |
-		Rights.fd_filestat_get | Rights.fd_filestat_set_times | Rights.path_remove_directory | Rights.path_unlink_file |
-		Rights.path_symlink;
+	Rights.path_create_file | Rights.path_link_source | Rights.path_link_target | Rights.path_open |
+	Rights.fd_readdir | Rights.path_readlink | Rights.path_rename_source | Rights.path_rename_target |
+	Rights.path_filestat_get | Rights.path_filestat_set_size | Rights.path_filestat_set_times |
+	Rights.fd_filestat_get | Rights.fd_filestat_set_times | Rights.path_remove_directory | Rights.path_unlink_file |
+	Rights.path_symlink;
 
 const FileBaseRights: rights = Rights.fd_datasync | Rights.fd_read | Rights.fd_seek | Rights.fd_fdstat_set_flags |
-		Rights.fd_sync | Rights.fd_tell | Rights.fd_write | Rights.fd_advise | Rights.fd_allocate | Rights.fd_filestat_get |
-		Rights.fd_filestat_set_size | Rights.fd_filestat_set_times | Rights.poll_fd_readwrite;
+	Rights.fd_sync | Rights.fd_tell | Rights.fd_write | Rights.fd_advise | Rights.fd_allocate | Rights.fd_filestat_get |
+	Rights.fd_filestat_set_size | Rights.fd_filestat_set_times | Rights.poll_fd_readwrite;
 
 const DirectoryInheritingRights: rights = DirectoryBaseRights | FileBaseRights;
 
@@ -244,7 +244,7 @@ class VirtualRootFileSystem {
 		for (const [mountPoint, node] of this.mountPoints) {
 			const root = node.deviceDriver.uri;
 			const rootStr = root.toString();
-			if (uriStr === rootStr || (uriStr.startsWith(rootStr) && uriStr.charAt(rootStr.length) === '/')) {
+			if (uriStr === rootStr || (uriStr.startsWith(rootStr) && uriStr.charAt(rootStr.length - 1) === '/')) {
 				return [mountPoint, root];
 			}
 		}
@@ -296,7 +296,7 @@ export function create(deviceId: DeviceId, rootFileDescriptors: { getRoot(device
 	const $driver = {
 		kind: DeviceDriverKind.fileSystem as const,
 		id: deviceId,
-		uri: Uri.from( { scheme: 'wasi-root', path: '/'} ),
+		uri: Uri.from({ scheme: 'wasi-root', path: '/' }),
 		makeVirtualPath(deviceDriver: FileSystemDeviceDriver, filepath: string): string | undefined {
 			return $fs.makeVirtualPath(deviceDriver, filepath);
 		},


### PR DESCRIPTION
When a `vscodeFileSystem` `MountPointDescriptor` is created with a `URI` like so:
```typescript
{ kind: 'vscodeFileSystem', uri: Uri.from({ scheme: 'fs-scheme', path: '/' }), mountPoint: '/usr/files'},
```
The resulting `descriptor.uri.toString()` is `fs-scheme:/` 

So the mapping of mountponits stored is :
```typescript
"fs-scheme:/" -> "usr/files/"
```

The method `getMountPoint` is given a uri to find in the rootFileSystem.
when given a uri where `{ sheme: "fs-scheme"; path: "abc.txt" }`, it fails to match. This is because `uri2.toString()` yields `"fs-scheme:/abc.txt"`
The condition `uriStr.charAt(rootStr.length) === "/"`expects a `/` at where `a` is and fails to find the mapping.
I'm unsure if `uri2Str` was expected to be `"fs-scheme://abc.txt", but that doesn't seem to be the case in my debugging during runtime. To fix this, I've removed that condition