### PR TITLE
resolve browser process run on terminate

### DIFF
--- a/wasm-wasi-core/src/web/process.ts
+++ b/wasm-wasi-core/src/web/process.ts
@@ -64,12 +64,14 @@ export class BrowserWasiProcess extends WasiProcess {
 		if (this.mainWorker !== undefined) {
 			this.mainWorker.terminate();
 		}
-		for (const worker of this.threadWorkers.values()) {
-			worker.terminate();
-		}
-		this.threadWorkers.clear();
+		await this.cleanUpWorkers();
 		await this.destroyStreams();
 		await this.cleanupFileDescriptors();
+
+		// when terinated, web workers silently exit, and there are no events
+		// to hook on to know when they are done. To ensure that the run promise resolves,
+		// we call it here so callers awaiting `process.run()` will get a result.
+		this.resolveRunPromise(result);
 		return result;
 	}
 


### PR DESCRIPTION
currently, when we use the following:
```typescript
await process.run()
```
The promise doesn't resolve when we call `process.terminate()` in browser scenarios. It does though resolve in node scenarios.
My assumption is that `webWorker.terminate()` immediately terminates the webwoker, not sending a `proc_exit` as expected by the `WasmProcess` base class, and so it does not resolve the run promise.