### PR TITLE
Return correct process exit code for browser processes

### DIFF
--- a/wasm-wasi-core/src/common/process.ts
+++ b/wasm-wasi-core/src/common/process.ts
@@ -247,7 +247,7 @@ export abstract class WasiProcess {
 		this.processService = {
 			proc_exit: async (_memory, exitCode: exitcode) => {
 				this._state = 'exiting';
-				await this.cleanupResources();
+				await this.processEnded(false);
 				this.resolveRunPromise(exitCode);
 				return Promise.resolve(Errno.success);
 			},
@@ -296,7 +296,7 @@ export abstract class WasiProcess {
 		});
 	}
 
-	protected abstract cleanupResources(): Promise<void>;
+	protected abstract processEnded(isExternallyTerminated: boolean): Promise<void>;
 
 	public abstract terminate(): Promise<number>;
 

--- a/wasm-wasi-core/src/common/process.ts
+++ b/wasm-wasi-core/src/common/process.ts
@@ -247,7 +247,7 @@ export abstract class WasiProcess {
 		this.processService = {
 			proc_exit: async (_memory, exitCode: exitcode) => {
 				this._state = 'exiting';
-				await this.processEnded(false);
+				await this.procExit();
 				this.resolveRunPromise(exitCode);
 				return Promise.resolve(Errno.success);
 			},
@@ -296,7 +296,7 @@ export abstract class WasiProcess {
 		});
 	}
 
-	protected abstract processEnded(isExternallyTerminated: boolean): Promise<void>;
+	protected abstract procExit(): Promise<void>;
 
 	public abstract terminate(): Promise<number>;
 

--- a/wasm-wasi-core/src/common/process.ts
+++ b/wasm-wasi-core/src/common/process.ts
@@ -247,7 +247,7 @@ export abstract class WasiProcess {
 		this.processService = {
 			proc_exit: async (_memory, exitCode: exitcode) => {
 				this._state = 'exiting';
-				await this.terminate();
+				await this.cleanupResources();
 				this.resolveRunPromise(exitCode);
 				return Promise.resolve(Errno.success);
 			},
@@ -295,6 +295,8 @@ export abstract class WasiProcess {
 			return exitCode;
 		});
 	}
+
+	protected abstract cleanupResources(): Promise<void>;
 
 	public abstract terminate(): Promise<number>;
 

--- a/wasm-wasi-core/src/desktop/process.ts
+++ b/wasm-wasi-core/src/desktop/process.ts
@@ -104,8 +104,10 @@ export class NodeWasiProcess extends WasiProcess {
 		return Promise.resolve();
 	}
 
-	protected async cleanupResources(): Promise<void> {
-		await this.mainWorker?.terminate();
+	protected async processEnded(isExternallyTerminated: boolean): Promise<void> {
+		if (!isExternallyTerminated) {
+			await this.mainWorker?.terminate();
+		}
 		await this.cleanUpWorkers();
 		await this.destroyStreams();
 		await this.cleanupFileDescriptors();
@@ -116,7 +118,7 @@ export class NodeWasiProcess extends WasiProcess {
 		if (this.mainWorker !== undefined) {
 			result = await this.mainWorker.terminate();
 		}
-		await this.cleanupResources();
+		await this.processEnded(true);
 		return result;
 	}
 

--- a/wasm-wasi-core/src/desktop/process.ts
+++ b/wasm-wasi-core/src/desktop/process.ts
@@ -104,14 +104,19 @@ export class NodeWasiProcess extends WasiProcess {
 		return Promise.resolve();
 	}
 
+	protected async cleanupResources(): Promise<void> {
+		await this.mainWorker?.terminate();
+		await this.cleanUpWorkers();
+		await this.destroyStreams();
+		await this.cleanupFileDescriptors();
+	}
+
 	public async terminate(): Promise<number> {
 		let result = 0;
 		if (this.mainWorker !== undefined) {
 			result = await this.mainWorker.terminate();
 		}
-		await this.cleanUpWorkers();
-		await this.destroyStreams();
-		await this.cleanupFileDescriptors();
+		await this.cleanupResources();
 		return result;
 	}
 

--- a/wasm-wasi-core/src/web/process.ts
+++ b/wasm-wasi-core/src/web/process.ts
@@ -59,7 +59,7 @@ export class BrowserWasiProcess extends WasiProcess {
 		}
 	}
 
-	protected async cleanupResources(): Promise<void> {
+	protected async processEnded(_isExternallyTerminated: boolean): Promise<void> {
 		if (this.mainWorker !== undefined) {
 			this.mainWorker.terminate();
 		}
@@ -70,12 +70,7 @@ export class BrowserWasiProcess extends WasiProcess {
 
 	public async terminate(): Promise<number> {
 		let result = 0;
-		if (this.mainWorker !== undefined) {
-			this.mainWorker.terminate();
-		}
-		await this.cleanUpWorkers();
-		await this.destroyStreams();
-		await this.cleanupFileDescriptors();
+		await this.processEnded(true);
 
 		// when terinated, web workers silently exit, and there are no events
 		// to hook on to know when they are done. To ensure that the run promise resolves,

--- a/wasm-wasi-core/src/web/process.ts
+++ b/wasm-wasi-core/src/web/process.ts
@@ -59,6 +59,15 @@ export class BrowserWasiProcess extends WasiProcess {
 		}
 	}
 
+	protected async cleanupResources(): Promise<void> {
+		if (this.mainWorker !== undefined) {
+			this.mainWorker.terminate();
+		}
+		await this.cleanUpWorkers();
+		await this.destroyStreams();
+		await this.cleanupFileDescriptors();
+	}
+
 	public async terminate(): Promise<number> {
 		let result = 0;
 		if (this.mainWorker !== undefined) {

--- a/wasm-wasi-core/src/web/process.ts
+++ b/wasm-wasi-core/src/web/process.ts
@@ -59,7 +59,7 @@ export class BrowserWasiProcess extends WasiProcess {
 		}
 	}
 
-	protected async processEnded(_isExternallyTerminated: boolean): Promise<void> {
+	protected async procExit(): Promise<void> {
 		if (this.mainWorker !== undefined) {
 			this.mainWorker.terminate();
 		}
@@ -70,9 +70,9 @@ export class BrowserWasiProcess extends WasiProcess {
 
 	public async terminate(): Promise<number> {
 		let result = 0;
-		await this.processEnded(true);
+		await this.procExit();
 
-		// when terinated, web workers silently exit, and there are no events
+		// when terminated, web workers silently exit, and there are no events
 		// to hook on to know when they are done. To ensure that the run promise resolves,
 		// we call it here so callers awaiting `process.run()` will get a result.
 		this.resolveRunPromise(result);

--- a/wasm-wasi-core/src/web/process.ts
+++ b/wasm-wasi-core/src/web/process.ts
@@ -27,7 +27,7 @@ export class BrowserServiceConnection extends ServiceConnection {
 	public postMessage(message: ServiceMessage): void {
 		try {
 			this.port.postMessage(message);
-		} catch(error) {
+		} catch (error) {
 			RAL().console.error(error);
 		}
 	}
@@ -69,7 +69,7 @@ export class BrowserWasiProcess extends WasiProcess {
 	}
 
 	public async terminate(): Promise<number> {
-		let result = 0;
+		const result = 0;
 		await this.procExit();
 
 		// when terminated, web workers silently exit, and there are no events


### PR DESCRIPTION
With a recent change, the `terminate` method in the `BrowserWasiProess` resolved the `runPromise` to ensure that the caller gets a return value on calling `WasmProcess.run()`. 
This had an unintended consequence of always resolving the `runPromise` with `0` as the `proc_exit` method calls `terminate` before resolving the `runPromise` to clean up the resources.

This change separates "terminating" and "cleaning up resources" and makes the `proc_exit` method only clean up resources. This ensures that the `BrowserWasiProcess` returns the correct exit code on the process exiting.