### PR TITLE
fix: broken links

### DIFF
--- a/wasm-wasi-core/README.md
+++ b/wasm-wasi-core/README.md
@@ -15,7 +15,7 @@ There is also an additional npm module `@vscode/wasm-wasi` that eases the API ac
 
 ## Example
 
-The source code of the example can be found [here](https://github.com/microsoft/vscode-wasi/blob/dbaeumer/expected-baboon-red/wasm-wasi/example/package.json)
+The source code of the example can be found [here](https://github.com/microsoft/vscode-wasm/blob/main/wasm-wasi/example/package.json)
 
 First we need to define a `package.json` for the extension that wants to execute a WASM process:
 

--- a/wasm-wasi/README.md
+++ b/wasm-wasi/README.md
@@ -12,7 +12,7 @@ With release version `0.11.0` the implementation details of the WASM support for
 
 ## Example
 
-The source code of the example can be found [here](https://github.com/microsoft/vscode-wasi/blob/dbaeumer/expected-baboon-red/wasm-wasi/example/package.json)
+The source code of the example can be found [here](https://github.com/microsoft/vscode-wasm/blob/main/wasm-wasi/example/package.json)
 
 First we need to define a `package.json` for the extension that wants to execute a WASM process:
 


### PR DESCRIPTION
> The source code of the example can be found [here](https://github.com/microsoft/vscode-wasi/blob/dbaeumer/expected-baboon-red/wasm-wasi/example/package.json)

Above have is broken link.
