### PR TITLE
Add custom exitcode to process.terminate

### DIFF
--- a/wasm-wasi-core/src/common/api.ts
+++ b/wasm-wasi-core/src/common/api.ts
@@ -13,6 +13,7 @@ import { MemoryFileSystem as MemoryFileSystemImpl } from './memoryFileSystemDriv
 import { WasiProcess as InternalWasiProcess } from './process';
 import { ReadableStream, WritableStream, WritableStreamEOT } from './streams';
 import { WasmPseudoterminalImpl } from './terminal';
+import { exitcode } from './wasi';
 
 export interface Environment {
 	[key: string]: string;
@@ -386,12 +387,12 @@ export interface WasmProcess {
 	/**
 	 * Runs the Wasm process.
 	 */
-	run(): Promise<number>;
+	run(): Promise<exitcode>;
 
 	/**
 	 * Terminate the Wasm process.
 	 */
-	 terminate(): Promise<number>;
+	terminate(exitCode?: exitcode): Promise<exitcode>;
 }
 
 export enum Filetype {

--- a/wasm-wasi-core/src/common/process.ts
+++ b/wasm-wasi-core/src/common/process.ts
@@ -275,11 +275,11 @@ export abstract class WasiProcess {
 		this._state = 'initialized';
 	}
 
-	public async run(): Promise<number> {
+	public async run(): Promise<exitcode> {
 		if (this._state !== 'initialized') {
 			throw new Error('WasiProcess is not initialized');
 		}
-		return new Promise<number>(async (resolve, reject) => {
+		return new Promise<exitcode>(async (resolve, reject) => {
 			this.resolveCallback = resolve;
 			const clock: Clock = Clock.create();
 			const wasiService: WasiService = Object.assign({},
@@ -298,7 +298,7 @@ export abstract class WasiProcess {
 
 	protected abstract procExit(): Promise<void>;
 
-	public abstract terminate(): Promise<number>;
+	public abstract terminate(exitCode?: exitcode): Promise<exitcode>;
 
 	protected async destroyStreams(): Promise<void> {
 		if (this._stdin !== undefined) {

--- a/wasm-wasi-core/src/desktop/process.ts
+++ b/wasm-wasi-core/src/desktop/process.ts
@@ -10,6 +10,7 @@ import { LogOutputChannel, Uri } from 'vscode';
 
 import { ProcessOptions } from '../common/api';
 import { ptr, u32 } from '../common/baseTypes';
+import type { exitcode } from '../common/wasi';
 import type { ServiceMessage, StartMainMessage, StartThreadMessage, WorkerMessage } from '../common/connection';
 import { WasiProcess } from '../common/process';
 import RAL from '../common/ral';
@@ -111,7 +112,7 @@ export class NodeWasiProcess extends WasiProcess {
 		await this.cleanupFileDescriptors();
 	}
 
-	public async terminate(): Promise<number> {
+	public async terminate(exitCode?: exitcode): Promise<exitcode> {
 		let result = 0;
 		if (this.mainWorker !== undefined) {
 			result = await this.mainWorker.terminate();
@@ -119,7 +120,7 @@ export class NodeWasiProcess extends WasiProcess {
 		await this.cleanUpWorkers();
 		await this.destroyStreams();
 		await this.cleanupFileDescriptors();
-		return result;
+		return exitCode ?? result;
 	}
 
 	private async cleanUpWorkers(): Promise<void> {

--- a/wasm-wasi-core/src/web/process.ts
+++ b/wasm-wasi-core/src/web/process.ts
@@ -9,6 +9,7 @@ import RAL from '../common/ral';
 import { WasiProcess } from '../common/process';
 import { WasiService, ServiceConnection } from '../common/service';
 import type { ptr, u32 } from '../common/baseTypes';
+import type { exitcode } from '../common/wasi';
 import type { ServiceMessage, StartMainMessage, StartThreadMessage, WorkerMessage } from '../common/connection';
 import type { ProcessOptions } from '../common/api';
 
@@ -68,15 +69,14 @@ export class BrowserWasiProcess extends WasiProcess {
 		await this.cleanupFileDescriptors();
 	}
 
-	public async terminate(): Promise<number> {
-		const result = 0;
+	public async terminate(exitCode: exitcode = 0): Promise<exitcode> {
 		await this.procExit();
 
 		// when terminated, web workers silently exit, and there are no events
 		// to hook on to know when they are done. To ensure that the run promise resolves,
 		// we call it here so callers awaiting `process.run()` will get a result.
-		this.resolveRunPromise(result);
-		return result;
+		this.resolveRunPromise(exitCode);
+		return exitCode;
 	}
 
 	protected async startMain(wasiService: WasiService): Promise<void> {

--- a/wasm-wasi/src/api/v1.ts
+++ b/wasm-wasi/src/api/v1.ts
@@ -10,6 +10,8 @@ import { Event, Extension, ExtensionContext, extensions as Extensions, Pseudoter
 import semverParse = require('semver/functions/parse');
 import semverSatisfies = require('semver/functions/satisfies');
 
+export type exitcode = number;
+
 export interface Environment {
 	[key: string]: string;
 }
@@ -397,12 +399,12 @@ export interface WasmProcess {
 	/**
 	 * Runs the Wasm process.
 	 */
-	run(): Promise<number>;
+	run(): Promise<exitcode>;
 
 	/**
 	 * Terminate the Wasm process.
 	 */
-	 terminate(): Promise<number>;
+	terminate(exitCode?: exitcode): Promise<exitcode>;
 }
 
 export enum Filetype {


### PR DESCRIPTION
### Description:
`process.run()` now can return a custom exit code when `process.terminate()` is triggered externally. It avoids the misleading default 0 exit code, which could falsely indicate success.

### Changes:
Add an extra optional argument `exitCode?: exitcode` to `process.terminate`.