### PR TITLE
fix assumptions about how fd_prestat_get may be called

### DIFF
--- a/wasm-wasi-core/src/common/process.ts
+++ b/wasm-wasi-core/src/common/process.ts
@@ -242,7 +242,7 @@ export abstract class WasiProcess {
 
 		this.environmentService = EnvironmentWasiService.create(
 			this.fileDescriptors, this.programName,
-			this.preOpenDirectories.entries(), options
+			Array.from(this.preOpenDirectories.entries()), options
 		);
 		this.processService = {
 			proc_exit: async (_memory, exitCode: exitcode) => {

--- a/wasm-wasi-core/src/common/test/index.ts
+++ b/wasm-wasi-core/src/common/test/index.ts
@@ -91,7 +91,7 @@ export function createWasiService(workspaceContent: WorkspaceContent): WasiServi
 
 	const clock = Clock.create();
 	const fileSystemService = DeviceWasiService.create(deviceDrivers, fileDescriptors, clock, undefined, options);
-	const environmentService = EnvironmentWasiService.create(fileDescriptors, 'testApp', preOpenDirectories.entries(), options);
+	const environmentService = EnvironmentWasiService.create(fileDescriptors, 'testApp', Array.from(preOpenDirectories.entries()), options);
 	const clockService = ClockWasiService.create(clock);
 	const result: WasiService = Object.assign({}, NoSysWasiService, environmentService, clockService, fileSystemService);
 	return result;


### PR DESCRIPTION
The current implementation of `fd_prestat_get` does not appears to handle the following cases properly:

- fd_prestat_get is called on the same file descriptor again
- fd_prestat_get is called on stdio file descriptors (fd < 3)
- fd_prestat_get is called in non sequential order of file descriptors

For testing, I used the `./wasm-wasi/example` project and modified the `hello.c` and `extension.ts`:

```c
#include <stdio.h>
#include <string.h>

// Relies on https://github.com/WebAssembly/wasi-libc

int main() {
  int i = 2;
  while (i--) {
    __wasi_fd_t fd = 6;
    while (fd--) {
      __wasi_prestat_t prestat;
      __wasi_errno_t ret = __wasi_fd_prestat_get(fd, &prestat);
      printf("fd_prestat_get(%d): %s (%d)\n", fd, strerror(ret), ret);
    }
    printf("\n");
  }
}
```

I modified the call to `createProcess` in `extension.ts` to add an additional preopen directory:
```ts
const process = await wasm.createProcess('hello', module, {
	stdio: pty.stdio,
	trace: true,
	mountPoints: [{ kind: "memoryFileSystem", fileSystem: await wasm.createMemoryFileSystem(), mountPoint: "/foo" }]
});
``` 

Before:
```
fd_prestat_get(5): Success (0)
fd_prestat_get(4): Success (0)
fd_prestat_get(3): Bad file descriptor (8)
fd_prestat_get(2): Invalid argument (28)
fd_prestat_get(1): Invalid argument (28)
fd_prestat_get(0): Invalid argument (28)

fd_prestat_get(5): Invalid argument (28)
fd_prestat_get(4): Invalid argument (28)
fd_prestat_get(3): Invalid argument (28)
fd_prestat_get(2): Invalid argument (28)
fd_prestat_get(1): Invalid argument (28)
fd_prestat_get(0): Invalid argument (28)
```

After:
```
fd_prestat_get(5): Bad file descriptor (8)
fd_prestat_get(4): Success (0)
fd_prestat_get(3): Success (0)
fd_prestat_get(2): Bad file descriptor (8)
fd_prestat_get(1): Bad file descriptor (8)
fd_prestat_get(0): Bad file descriptor (8)

fd_prestat_get(5): Bad file descriptor (8)
fd_prestat_get(4): Success (0)
fd_prestat_get(3): Success (0)
fd_prestat_get(2): Bad file descriptor (8)
fd_prestat_get(1): Bad file descriptor (8)
fd_prestat_get(0): Bad file descriptor (8)
```

The new output matches exactly what I got from wasmtime with `wasmtime run --dir=.::/foo --dir=.::/bar hello.wasm`.

